### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -17,18 +17,6 @@
 
 package org.apache.commons.csv;
 
-import static org.apache.commons.csv.Constants.BACKSLASH;
-import static org.apache.commons.csv.Constants.COMMA;
-import static org.apache.commons.csv.Constants.COMMENT;
-import static org.apache.commons.csv.Constants.CR;
-import static org.apache.commons.csv.Constants.CRLF;
-import static org.apache.commons.csv.Constants.DOUBLE_QUOTE_CHAR;
-import static org.apache.commons.csv.Constants.EMPTY;
-import static org.apache.commons.csv.Constants.LF;
-import static org.apache.commons.csv.Constants.PIPE;
-import static org.apache.commons.csv.Constants.SP;
-import static org.apache.commons.csv.Constants.TAB;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -2017,7 +2005,7 @@ public final class CSVFormat implements Serializable {
         int c;
         while (-1 != (c = bufferedReader.read())) {
             builder.append((char) c);
-            final boolean isDelimiterStart = isDelimiter((char) c, builder.toString() + new String(bufferedReader.lookAhead(delimLength - 1)), pos, delim,
+            final boolean isDelimiterStart = isDelimiter(((char)) c, builder + new String(bufferedReader.lookAhead(delimLength - 1)), pos, delim,
                     delimLength);
             if (c == CR || c == LF || c == escape || isDelimiterStart) {
                 // write out segment up until this char

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -147,7 +147,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
             try {
                 return CSVParser.this.nextRecord();
             } catch (final IOException e) {
-                throw new UncheckedIOException(e.getClass().getSimpleName() + " reading next record: " + e.toString(), e);
+                throw new UncheckedIOException(e.getClass().getSimpleName() + " reading next record: " + e, e);
             }
         }
 

--- a/src/main/java/org/apache/commons/csv/Token.java
+++ b/src/main/java/org/apache/commons/csv/Token.java
@@ -40,7 +40,7 @@ final class Token {
         EORECORD,
 
         /** Token is a comment line. */
-        COMMENT
+        COMMENT;
     }
 
     /** length of the initial token (content-)buffer */
@@ -71,6 +71,6 @@ final class Token {
      */
     @Override
     public String toString() {
-        return type.name() + " [" + content.toString() + "]";
+        return type.name() + " [" + content + "]";
     }
 }


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:1727940249 -->
<!-- fingerprint:-526606495 -->
<!-- fingerprint:-646940647 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (3)
